### PR TITLE
fix: xroad client

### DIFF
--- a/src/clients/soap-client.ts
+++ b/src/clients/soap-client.ts
@@ -1,41 +1,41 @@
-import {XRoadClient} from "./client";
-import {IXRoadSoapRequest} from "../types/IXRoadSoapRequest";
-import {fetchData} from "../fetch-data";
-import {IXRoadService} from "../types/IXRoadService";
-import uuidv4 from "uuid/v4";
-import parser from "fast-xml-parser";
+import { XRoadClient } from './client';
+import { IXRoadSoapRequest } from '../types/IXRoadSoapRequest';
+import { fetchData } from '../fetch-data';
+import { IXRoadService } from '../types/IXRoadService';
+import { v4 as uuidv4 } from 'uuid';
+import parser from 'fast-xml-parser';
 
 const parserOptions = {
     parseNodeValue: false,
-    ignoreAttributes : true,
-    trimValues: false
+    ignoreAttributes: true,
+    trimValues: false,
 };
 
 export class XRoadSoapClient extends XRoadClient<IXRoadSoapRequest> {
-
     public request = (req: IXRoadSoapRequest) => {
         return this.soapRequest(req);
     };
 
     public soapRequest = (req: IXRoadSoapRequest): Promise<any> => {
-
         return fetchData(this.securityServerUrl, {
             method: 'POST',
             headers: {
-                "Content-Type": 'text/xml',
-                ...(req.headers || {})
+                'Content-Type': 'text/xml',
+                ...(req.headers || {}),
             },
             agentOptions: this.agentOptions,
-            body: this.createXRoadSoapEnvelopeBody(req.service, req.body)
+            body: this.createXRoadSoapEnvelopeBody(req.service, req.body),
         }).then(body => {
             return parser.parse(body as string, parserOptions);
         });
     };
 
-    createXRoadSoapEnvelopeBody = (xroadService: IXRoadService, bodyContent: string) => {
+    createXRoadSoapEnvelopeBody = (
+        xroadService: IXRoadService,
+        bodyContent: string
+    ) => {
         // Get data from SEFAZ
-        return (
-            `<SOAP-ENV:Envelope
+        return `<SOAP-ENV:Envelope
             xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
             xmlns:xrd="http://x-road.eu/xsd/xroad.xsd"
             xmlns:id="http://x-road.eu/xsd/identifiers">
@@ -47,10 +47,14 @@ export class XRoadSoapClient extends XRoadClient<IXRoadSoapRequest> {
                     <id:subsystemCode>${this.subsystemCode}</id:subsystemCode>
                 </xrd:client>
                 <xrd:service id:objectType="SERVICE">
-                    <id:xRoadInstance>${xroadService.xRoadInstance}</id:xRoadInstance>
+                    <id:xRoadInstance>${
+                        xroadService.xRoadInstance
+                    }</id:xRoadInstance>
                     <id:memberClass>${xroadService.memberClass}</id:memberClass>
                     <id:memberCode>${xroadService.memberCode}</id:memberCode>
-                    <id:subsystemCode>${xroadService.subsystemCode}</id:subsystemCode>
+                    <id:subsystemCode>${
+                        xroadService.subsystemCode
+                    }</id:subsystemCode>
                     <id:serviceCode>${xroadService.serviceCode}</id:serviceCode>
                 </xrd:service>
                 <xrd:protocolVersion>4.0</xrd:protocolVersion>
@@ -59,7 +63,6 @@ export class XRoadSoapClient extends XRoadClient<IXRoadSoapRequest> {
             <SOAP-ENV:Body>
                 ${bodyContent}
             </SOAP-ENV:Body>
-        </SOAP-ENV:Envelope>`
-        );
+        </SOAP-ENV:Envelope>`;
     };
 }

--- a/src/fetch-data.ts
+++ b/src/fetch-data.ts
@@ -1,6 +1,6 @@
 export const fetchData = (url: string, config: Record<string, any>) => {
     return fetch(url, config).then(res => {
-        if (res.status === 200) {
+        if (res.status >= 200 && res.status < 300) {
             const contentType = res.headers.get('content-type');
             if (contentType && contentType.indexOf('application/json') !== -1) {
                 return res.json();


### PR DESCRIPTION
**Fix UUID import issue, improve status code handling, and address error handling in fetchData**

- Fixed the UUID import issue (`Error: Package subpath './v4' is not defined by "exports"`) by updating to `import { v4 as uuidv4 } from "uuid"`.
- Improved `fetchData` function to correctly handle status codes in the 200-299 range, preventing valid responses (e.g., 201) from being treated as errors.